### PR TITLE
use node-fetch for users with node versions < v18

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,4 +1,7 @@
 require('dotenv').config();
+// use node-fetch library for compatibility
+// with node versions < v18
+const _fetch = require('node-fetch');
 
 DEFAULT_LOOKBACK_PERIOD = 16;
 
@@ -8,7 +11,7 @@ const getWeeklyDSAPointsForUser = async (
   userId,
   limit = DEFAULT_LOOKBACK_PERIOD
 ) => {
-  const res = await fetch(`${API_URL}/weeklyScores/${userId}?limit=${limit}`);
+  const res = await _fetch(`${API_URL}/weeklyScores/${userId}?limit=${limit}`);
   const weeklyPoints = await res.json();
 
   return weeklyPoints;
@@ -18,7 +21,7 @@ const getWeeklyCommitsForUser = async (
   userId,
   limit = DEFAULT_LOOKBACK_PERIOD
 ) => {
-  const res = await fetch(`${API_URL}/weeklyCommits/${userId}?limit=${limit}`);
+  const res = await _fetch(`${API_URL}/weeklyCommits/${userId}?limit=${limit}`);
   const weeklyCommits = await res.json();
 
   return weeklyCommits;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/dotenv": {
@@ -21,6 +22,44 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "node-fetch": "^2.7.0"
   }
 }


### PR DESCRIPTION
`fetch` is not native to nodejs until v18 and doesn't have fully official support until v21. If a learner does this lab with a version of node between 18 and 21, they'll be good to go (maybe with a warning saying fetch isn't fully official). Learners with versions below 18 will not be able to do the lab until they upgrade node. That's a major pain and I don't want them to have to do this.

As a workaround, this PR adds the `node-fetch` library which I tested with node versions 12, 14, 16, 18, and 20 with no problems. Please note that `node-fetch` v2.x has to be used because v3 of node-fetch does not support the `require` syntax.